### PR TITLE
Update to correct features and settings

### DIFF
--- a/src/mop3.md
+++ b/src/mop3.md
@@ -44,22 +44,23 @@ However, it does not forward the packet to node 1, since it is the originator of
 
 ```admonish danger title="Unsubscribing from a multicast group"
 The RPL standard does not specify how to unsubscribe from a multicast group.
+The implementation, however, provides a mechanism through `No-Path DAO` messages.
 ```
 
 ## Usage with smoltcp ##
 
 The RPL network can be formed using the `smoltcp` library.
-The following feature flags need to be enabled: `rpl-mop-2` and `proto-sixlowpan`.
+The following feature flags need to be enabled: `rpl-mop-3` and `proto-sixlowpan`.
 Additionally, the `proto-sixlowpan-fragmentation` feature can be enabled to allow for fragmentation of 6LoWPAN packets.
 
 The following configuration should be added to the configuration struct for the interface:
 ```rust
-config.rpl = RplConfig::new(RplModeOfOperation::StoringMode);
+config.rpl = RplConfig::new(RplModeOfOperation::StoringModeWithMulticast);
 ```
 
 When using RPL as a root node, the following configuration should be added:
 ```rust
-config.rpl = RplConfig::new(RplModeOfOperation::StoringMode)
+config.rpl = RplConfig::new(RplModeOfOperation::StoringModeWithMulticast)
     .add_root_config(RplRootConfig::new(
         RplInstanceId::from(30), // Change this to the desired RPL Instance ID
         Ipv6Address::default(),  // Change this to the desired DODAG ID

--- a/src/mop3.md
+++ b/src/mop3.md
@@ -67,6 +67,17 @@ config.rpl = RplConfig::new(RplModeOfOperation::StoringModeWithMulticast)
     ));
 ```
 
+To allow `smoltcp` to do the duplication, a non-empty buffer needs to be allocated specifically for multicast:
+```rust
+let mut interface = Interface::<'static>::new(
+    config,
+    &mut device,
+    vec![PacketMetadata::EMPTY; 16], // the multicast buffer
+    vec![0; 2048],
+    Instant::now(),
+);
+```
+
 The interface should join a multicast group:
 ```rust
 interface.join_multicast_group(


### PR DESCRIPTION
Hi,

I found some issues with the documentation on mop 3. Things that this PR fixes:
* To use mop3, you need to enable the `rpl-mop3` feature
* To configure the use of multicast, you need to configure it through `RplModeOfOperation::StoringModeWithMulticast` and not `RplModeOfOperation::StoringMode`
* To enable the LL duplication needed for multicast, a buffer must be allocated in the interface.

Things that still might not be 100% correct:
* The current implementation does provide a way to unsubscribe through a `No-Path DAO` which is out-of-spec, but very convenient when using in combination with `OF0` in real life scenarios
* As per RFC 6550, the multicast capability should be enabled by default when enabling mop2. The root then should configure to enable multicast through a DIO. 